### PR TITLE
Utilize editedOlympian async function to refactor youngest and oldest query

### DIFF
--- a/controllers/olympiansController.js
+++ b/controllers/olympiansController.js
@@ -44,15 +44,8 @@ const index = async (request, response) => {
                 .orderBy('Age', 'ASC')
                 .limit(1)
                 .then(async (youth) => {
-                    let medalCount = await Olympian.totalMedals(youth[0]['Name'])
-                    let youngestOlympian = {
-                        name: youth[0]['Name'],
-                        team: youth[0]['Team'],
-                        age: youth[0]['Age'],
-                        sport: youth[0]['Sport'],
-                        total_medals_won: medalCount
-                    }
-                    return youngestOlympian;
+                    let edited = await editedOlympian(youth)
+                    return edited;
                 })
                 .then((youngest) => {
                     response.status(200).json(youngest);
@@ -62,15 +55,8 @@ const index = async (request, response) => {
                 .orderBy('Age', 'DESC')
                 .limit(1)
                 .then(async (elder) => {
-                    let medalCount = await Olympian.totalMedals(elder[0]['Name'])
-                    let oldestOlympian = {
-                        name: elder[0]['Name'],
-                        team: elder[0]['Team'],
-                        age: elder[0]['Age'],
-                        sport: elder[0]['Sport'],
-                        total_medals_won: medalCount
-                    }
-                    return oldestOlympian;
+                    let edited = await editedOlympian(elder)
+                    return edited;
                 })
                 .then((oldest) => {
                     response.status(200).json(oldest);

--- a/controllers/olympiansController.js
+++ b/controllers/olympiansController.js
@@ -44,7 +44,7 @@ const index = async (request, response) => {
                 .orderBy('Age', 'ASC')
                 .limit(1)
                 .then(async (youth) => {
-                    let edited = await editedOlympian(youth)
+                    let edited = await editedOlympian(youth[0])
                     return edited;
                 })
                 .then((youngest) => {
@@ -55,7 +55,7 @@ const index = async (request, response) => {
                 .orderBy('Age', 'DESC')
                 .limit(1)
                 .then(async (elder) => {
-                    let edited = await editedOlympian(elder)
+                    let edited = await editedOlympian(elder[0])
                     return edited;
                 })
                 .then((oldest) => {


### PR DESCRIPTION
# Description

During code review, noticed I could reuse async function created for all Olympians to streamline youngest and oldest query. No new dependencies. 

Fixes # (issue)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Postman verification of both youngest and oldest endpoints to confirm no change to response

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes